### PR TITLE
Add Kinesis endpoint to NewStream to allow for localtesting against localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ func main() {
 		Interval:     time.Millisecond * 1000,
 		IteratorType: kcl.IteratorTypeLatest,
 	}
-	k, err := kcl.NewStream(sess, os.Getenv("AWS_KINESIS_STREAM"), s, config)
+	k, err := kcl.NewStream(sess, os.Getenv("AWS_KINESIS_ENDPIONT"), os.Getenv("AWS_KINESIS_STREAM"), s, config)
 	if err != nil {
 		panic(err)
 	}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ func main() {
 		Interval:     time.Millisecond * 1000,
 		IteratorType: kcl.IteratorTypeLatest,
 	}
-	k, err := kcl.NewStream(sess, os.Getenv("AWS_KINESIS_ENDPIONT"), os.Getenv("AWS_KINESIS_STREAM"), s, config)
+	k, err := kcl.NewStream(sess, os.Getenv("AWS_KINESIS_ENDPOINT"), os.Getenv("AWS_KINESIS_STREAM"), s, config)
 	if err != nil {
 		panic(err)
 	}

--- a/kinesis.go
+++ b/kinesis.go
@@ -2,8 +2,9 @@ package kcl
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
@@ -74,8 +75,8 @@ type HandlerFunc func(records []*kinesis.Record)
 // NewStream will return a pointer to a stream that you can listen on. Stream is capable of
 // managing multiple shards, printing out log statements, and polling Kinesis at a regular
 // interval.
-func NewStream(sess *session.Session, stream string, store Store, config Config) (*Stream, error) {
-	svc := kinesis.New(sess)
+func NewStream(sess *session.Session, kinesisEndpoint string, stream string, store Store, config Config) (*Stream, error) {
+	svc := kinesis.New(sess, &aws.Config{Endpoint: aws.String(kinesisEndpoint)})
 	resp, err := svc.DescribeStream(&kinesis.DescribeStreamInput{
 		StreamName: aws.String(stream),
 	})


### PR DESCRIPTION
A small suggestion that allows this code to be used against a [localstack](https://github.com/localstack/localstack) instance for local testing/dev.

A bit more work should probably go into this to test and assume a default. 